### PR TITLE
Generic type 'E' is never used in Transition interface and unused import...

### DIFF
--- a/src/main/java/se/fearless/fettle/StateMachine.java
+++ b/src/main/java/se/fearless/fettle/StateMachine.java
@@ -1,7 +1,5 @@
 package se.fearless.fettle;
 
-import se.fearless.fettle.impl.BasicTransition;
-
 import java.util.Collection;
 import java.util.Map;
 
@@ -60,5 +58,5 @@ public interface StateMachine<S, E, C> {
 	 * @param fromState the state to retrieve the outgoing transitions from.
 	 * @return a map from all registered events in the fromState to the transitions they would trigger if fired.
 	 */
-	Map<E, Collection<? extends Transition<S, E, C>>> getPossibleTransitions(S fromState);
+	Map<E, Collection<? extends Transition<S, C>>> getPossibleTransitions(S fromState);
 }

--- a/src/main/java/se/fearless/fettle/Transition.java
+++ b/src/main/java/se/fearless/fettle/Transition.java
@@ -1,6 +1,6 @@
 package se.fearless.fettle;
 
-public interface Transition<S, E, C> {
+public interface Transition<S, C> {
 	S getTo();
 
 	boolean isSatisfied(C context);

--- a/src/main/java/se/fearless/fettle/TransitionModel.java
+++ b/src/main/java/se/fearless/fettle/TransitionModel.java
@@ -1,7 +1,5 @@
 package se.fearless.fettle;
 
-import se.fearless.fettle.impl.BasicTransition;
-
 import java.util.Collection;
 import java.util.Map;
 
@@ -29,5 +27,5 @@ public interface TransitionModel<S, E, C> {
 
 	C getDefaultContext();
 
-    Map<E, Collection<? extends Transition<S, E, C>>> getPossibleTransitions(S fromState);
+    Map<E, Collection<? extends Transition<S, C>>> getPossibleTransitions(S fromState);
 }

--- a/src/main/java/se/fearless/fettle/impl/AbstractTransitionModel.java
+++ b/src/main/java/se/fearless/fettle/impl/AbstractTransitionModel.java
@@ -105,8 +105,8 @@ public abstract class AbstractTransitionModel<S, E, C> implements TransitionMode
 	}
 
 	@Override
-	public Map<E, Collection<? extends Transition<S, E, C>>> getPossibleTransitions(S fromState) {
-		Map<E, Collection<? extends Transition<S, E, C>>> map = GuavaReplacement.newHashMap();
+	public Map<E, Collection<? extends Transition<S, C>>> getPossibleTransitions(S fromState) {
+		Map<E, Collection<? extends Transition<S, C>>> map = GuavaReplacement.newHashMap();
 		Map<E, Collection<BasicTransition<S, E, C>>> transitions = transitionMap.get(fromState);
 		if (transitions != null) {
 			map.putAll(transitions);
@@ -114,7 +114,7 @@ public abstract class AbstractTransitionModel<S, E, C> implements TransitionMode
 
 		for (Map.Entry<E, Collection<BasicTransition<S, E, C>>> entry : fromAllTransitions.entrySet()) {
 			@SuppressWarnings("unchecked")
-			Collection<Transition<S, E, C>> transitionCollection = (Collection<Transition<S, E, C>>) map.get(entry.getKey());
+			Collection<Transition<S, C>> transitionCollection = (Collection<Transition<S, C>>) map.get(entry.getKey());
 			if (transitionCollection == null) {
 				transitionCollection = GuavaReplacement.newArrayList();
 			}

--- a/src/main/java/se/fearless/fettle/impl/BasicTransition.java
+++ b/src/main/java/se/fearless/fettle/impl/BasicTransition.java
@@ -8,7 +8,7 @@ import se.fearless.fettle.util.GuavaReplacement;
 
 import java.util.Collection;
 
-public class BasicTransition<S, E, C> implements Transition<S, E, C> {
+public class BasicTransition<S, E, C> implements Transition<S, C> {
 	private final S to;
 	private final Condition<C> condition;
 	private final Collection<Action<S, E, C>> actions = GuavaReplacement.newArrayList();

--- a/src/main/java/se/fearless/fettle/impl/TemplateBasedStateMachine.java
+++ b/src/main/java/se/fearless/fettle/impl/TemplateBasedStateMachine.java
@@ -61,7 +61,7 @@ public class TemplateBasedStateMachine<S, E, C> implements StateMachine<S,E,C> {
 	}
 
 	@Override
-	public Map<E,Collection<? extends Transition<S,E,C>>> getPossibleTransitions(S fromState) {
+	public Map<E,Collection<? extends Transition<S, C>>> getPossibleTransitions(S fromState) {
 		return model.getPossibleTransitions(fromState);
 	}
 }

--- a/src/test/java/se/fearless/fettle/TraverseTest.java
+++ b/src/test/java/se/fearless/fettle/TraverseTest.java
@@ -27,7 +27,7 @@ public class TraverseTest {
 	public void queryWithNoTransitions() throws Exception {
 		StateMachine<States, String, Boolean> stateMachine = createStateMachine(builder);
 
-		Map<String, Collection<? extends Transition<States, String, Boolean>>> transitionMap = stateMachine.getPossibleTransitions(States.INITIAL);
+		Map<String, Collection<? extends Transition<States, Boolean>>> transitionMap = stateMachine.getPossibleTransitions(States.INITIAL);
 
 		assertTrue(transitionMap.isEmpty());
 	}
@@ -37,10 +37,10 @@ public class TraverseTest {
 		builder.transition().from(States.INITIAL).to(States.ONE).on("foo");
 		StateMachine<States, String, Boolean> stateMachine = createStateMachine(builder);
 
-		Map<String, Collection<? extends Transition<States, String, Boolean>>> transitionMap = stateMachine.getPossibleTransitions(States.INITIAL);
+		Map<String, Collection<? extends Transition<States, Boolean>>> transitionMap = stateMachine.getPossibleTransitions(States.INITIAL);
 		assertEquals(1, transitionMap.size());
-		Collection<? extends Transition<States, String, Boolean>> transitions = transitionMap.get("foo");
-		Transition<States, String, Boolean> transition = Iterables.getOnlyElement(transitions);
+		Collection<? extends Transition<States, Boolean>> transitions = transitionMap.get("foo");
+		Transition<States, Boolean> transition = Iterables.getOnlyElement(transitions);
 		assertEquals(States.ONE, transition.getTo());
 	}
 
@@ -60,9 +60,9 @@ public class TraverseTest {
 		});
 		StateMachine<States, String, Boolean> stateMachine = createStateMachine(builder);
 
-		Map<String, Collection<? extends Transition<States, String, Boolean>>> transitionMap = stateMachine.getPossibleTransitions(States.INITIAL);
+		Map<String, Collection<? extends Transition<States, Boolean>>> transitionMap = stateMachine.getPossibleTransitions(States.INITIAL);
 		assertEquals(1, transitionMap.size());
-		Collection<? extends Transition<States, String, Boolean>> transitions = transitionMap.get("foo");
+		Collection<? extends Transition<States, Boolean>> transitions = transitionMap.get("foo");
 
 		checkExistenceOfTransitionsTo(States.ONE, transitions);
 		checkExistenceOfTransitionsTo(States.TWO, transitions);
@@ -75,10 +75,10 @@ public class TraverseTest {
 		builder.transition().from(States.THREE).to(States.ONE).on("foo");
 		StateMachine<States, String, Boolean> stateMachine = createStateMachine(builder);
 
-		Map<String, Collection<? extends Transition<States, String, Boolean>>> transitionMap = stateMachine.getPossibleTransitions(States.INITIAL);
+		Map<String, Collection<? extends Transition<States, Boolean>>> transitionMap = stateMachine.getPossibleTransitions(States.INITIAL);
 		assertEquals(1, transitionMap.size());
-		Collection<? extends Transition<States, String, Boolean>> transitions = transitionMap.get("foo");
-		Transition<States, String, Boolean> transition = Iterables.getOnlyElement(transitions);
+		Collection<? extends Transition<States, Boolean>> transitions = transitionMap.get("foo");
+		Transition<States, Boolean> transition = Iterables.getOnlyElement(transitions);
 		assertEquals(States.ONE, transition.getTo());
 	}
 
@@ -98,9 +98,9 @@ public class TraverseTest {
 		});
 		StateMachine<States, String, Boolean> stateMachine = createStateMachine(builder);
 
-		Map<String, Collection<? extends Transition<States, String, Boolean>>> transitionMap = stateMachine.getPossibleTransitions(States.INITIAL);
+		Map<String, Collection<? extends Transition<States, Boolean>>> transitionMap = stateMachine.getPossibleTransitions(States.INITIAL);
 		assertEquals(1, transitionMap.size());
-		Collection<? extends Transition<States, String, Boolean>> transitions = transitionMap.get("foo");
+		Collection<? extends Transition<States, Boolean>> transitions = transitionMap.get("foo");
 
 		checkExistenceOfTransitionsTo(States.ONE, transitions);
 		checkExistenceOfTransitionsTo(States.TWO, transitions);
@@ -122,9 +122,9 @@ public class TraverseTest {
 		});
 		StateMachine<States, String, Boolean> stateMachine = createStateMachine(builder);
 
-		Map<String, Collection<? extends Transition<States, String, Boolean>>> transitionMap = stateMachine.getPossibleTransitions(States.INITIAL);
+		Map<String, Collection<? extends Transition<States, Boolean>>> transitionMap = stateMachine.getPossibleTransitions(States.INITIAL);
 		assertEquals(1, transitionMap.size());
-		Collection<? extends Transition<States, String, Boolean>> transitions = transitionMap.get("foo");
+		Collection<? extends Transition<States, Boolean>> transitions = transitionMap.get("foo");
 
 		checkExistenceOfTransitionsTo(States.ONE, transitions);
 		checkExistenceOfTransitionsTo(States.TWO, transitions);
@@ -136,10 +136,10 @@ public class TraverseTest {
 		return template.newStateMachine(States.INITIAL);
 	}
 
-	private void checkExistenceOfTransitionsTo(final States state, Collection<? extends Transition<States, String, Boolean>> transitions) {
-		Transition<States, String, Boolean> transition1 = Iterables.find(transitions, new Predicate<Transition<States, String, Boolean>>() {
+	private void checkExistenceOfTransitionsTo(final States state, Collection<? extends Transition<States, Boolean>> transitions) {
+		Transition<States, Boolean> transition1 = Iterables.find(transitions, new Predicate<Transition<States, Boolean>>() {
 			@Override
-			public boolean apply(Transition<States, String, Boolean> input) {
+			public boolean apply(Transition<States, Boolean> input) {
 				return input.getTo() == state;
 			}
 		});


### PR DESCRIPTION
I am not able to see why it would be needed, all tests still pass. 
